### PR TITLE
Backend Unit Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ jdk:
 node_js:
 - "node"
 # specifies that the latest version of node_js should be used.
-
+services:
+  - cassandra
 addons:
     - chrome: stable
 apt:

--- a/scripts/springCassScript.sh
+++ b/scripts/springCassScript.sh
@@ -2,6 +2,7 @@
 #script file for tests regarding the spring application.
 
 cd ./springCass
+cp src/test/resources/configs/application.properties src/test/resources/application.properties
 gradle test
 #here you could add your test for Spring. keep in mind to track whether the command to run the test fails as you can see below,
 #since the script otherwise won´t fail and exit with 0, causing travis to think that all tests were succsesfull.

--- a/springCass/build.gradle
+++ b/springCass/build.gradle
@@ -41,6 +41,4 @@ dependencies {
     compile 'org.springframework.kafka:spring-kafka:2.1.6.RELEASE'
     testCompile 'org.mockito:mockito-core:2.7.22'
 
-    // Embedded cassandra for integration testing with database.
-    testCompile('org.cassandraunit:cassandra-unit-spring:2.2.2.1')
 }

--- a/springCass/src/test/java/app/feedback/FeedbackControllerTest.java
+++ b/springCass/src/test/java/app/feedback/FeedbackControllerTest.java
@@ -31,7 +31,7 @@ public class FeedbackControllerTest {
     private MockMvc mockMvc;
 
     @Before
-    public void setWac(){
+    public void setWac() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
     }
 

--- a/springCass/src/test/resources/application.properties
+++ b/springCass/src/test/resources/application.properties
@@ -1,6 +1,6 @@
 spring.data.cassandra.keyspace-name=sample
-spring.data.cassandra.contact-points=localhost
+spring.data.cassandra.contact-points=192.168.99.100
 spring.data.cassandra.port=9042
 
-spring.data.kafka.bootstrapAddress=localhost:9092
+spring.data.kafka.bootstrapAddress=192.168.99.100:9092
 app.topic.feedback=feedback

--- a/springCass/src/test/resources/application.properties
+++ b/springCass/src/test/resources/application.properties
@@ -1,6 +1,6 @@
 spring.data.cassandra.keyspace-name=sample
-spring.data.cassandra.contact-points=192.168.99.100
+spring.data.cassandra.contact-points=localhost
 spring.data.cassandra.port=9042
 
-spring.data.kafka.bootstrapAddress=192.168.99.100:9092
+spring.data.kafka.bootstrapAddress=localhost:9092
 app.topic.feedback=feedback

--- a/springCass/src/test/resources/configs/application.properties
+++ b/springCass/src/test/resources/configs/application.properties
@@ -1,0 +1,6 @@
+spring.data.cassandra.keyspace-name=sample
+spring.data.cassandra.contact-points=localhost
+spring.data.cassandra.port=9042
+
+spring.data.kafka.bootstrapAddress=localhost:9092
+app.topic.feedback=feedback


### PR DESCRIPTION
Ansatz mit Embedded Cassandra verworfen.
Cassandra zu Travis hinzugefügt und TestConfig entsprechend angepasst.

related to #60 
- Test lassen sich in CI ausführen
- Cassandra wird aber noch zum starten benötigt